### PR TITLE
added v-bind $attrs to input so we can bind standard non-prop html attrs to the input

### DIFF
--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -4,7 +4,7 @@
         ref="autocompleteRef"
         type="text"
         @input="handleInput"
-        v-bind="{...$attrs}"
+        v-bind="$attrs"
         v-model="searchText"
         :class="getInputClass"
         @focus="displayResults"

--- a/src/Autocomplete.vue
+++ b/src/Autocomplete.vue
@@ -4,6 +4,7 @@
         ref="autocompleteRef"
         type="text"
         @input="handleInput"
+        v-bind="{...$attrs}"
         v-model="searchText"
         :class="getInputClass"
         @focus="displayResults"


### PR DESCRIPTION
This should allow for consumers to pass in non-prop attrs such as placeholder, value, style, class, etc... into the input. This should allow setItem callback to properly set the "value" on the input rather than on the wrapping component root element (div) when a user selects an item from results list.